### PR TITLE
Make seshat compile on default options in Ubuntu 18.04 (c++11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=g++
 LINK=-lxerces-c -lm
-FLAGS = -O3 -Wno-unused-result #-I/path/to/boost/
+FLAGS = -O3 -Wno-unused-result -fpermissive #-I/path/to/boost/
 
 OBJFEAS=symfeatures.o featureson.o online.o
 OBJMUESTRA=sample.o stroke.o

--- a/rnnlib4seshat/DataExporter.hpp
+++ b/rnnlib4seshat/DataExporter.hpp
@@ -114,7 +114,7 @@ template <typename T> struct ParamVal: public Val {
   }
 
   bool load(istream& in, ostream& out = cout) {
-    return (in >> param);
+    return (bool)(in >> param);
   }
 };
 

--- a/rnnlib4seshat/Helpers.hpp
+++ b/rnnlib4seshat/Helpers.hpp
@@ -55,6 +55,7 @@ along with RNNLIB.  If not, see <http://www.gnu.org/licenses/>.*/
 #include <boost/math/distributions.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/range/irange.hpp>
+#include <boost/tuple/tuple_io.hpp>
 #include <math.h>
 #include <numeric>
 #include <utility>
@@ -151,20 +152,20 @@ typedef pair<const string, real_t> PCSD;
 typedef pair<string, int> PSI;
 typedef pair<int, string> PIS;
 typedef pair<string, string> PSS;
-typedef const tuple<real_t&, real_t&, real_t&, real_t&>& TDDDD;
-typedef const tuple<real_t&, real_t&, real_t&, real_t&, real_t&>& TDDDDD;
-typedef const tuple<real_t&, real_t&, real_t&>& TDDD;
-typedef const tuple<real_t&, real_t&, int&>& TDDI;
-typedef const tuple<real_t&, real_t&, real_t&>& TDDF;
-typedef const tuple<real_t&, real_t&, real_t>& TDDCF;
-typedef const tuple<real_t&, real_t&>& TDD;
-typedef const tuple<int, string>& TIS;
-typedef const tuple<int, int>& TII;
-typedef const tuple<int, real_t>& TID;
-typedef const tuple<int, set<int>&>& TISETI;
-typedef const tuple<int&, bool, int>& TIBI;
-typedef const tuple<real_t, Log<real_t>& >& TDL;
-typedef const tuple<real_t&, Log<real_t>, Log<real_t> >& TDLL;
+typedef const boost::tuple<real_t&, real_t&, real_t&, real_t&>& TDDDD;
+typedef const boost::tuple<real_t&, real_t&, real_t&, real_t&, real_t&>& TDDDDD;
+typedef const boost::tuple<real_t&, real_t&, real_t&>& TDDD;
+typedef const boost::tuple<real_t&, real_t&, int&>& TDDI;
+typedef const boost::tuple<real_t&, real_t&, real_t&>& TDDF;
+typedef const boost::tuple<real_t&, real_t&, real_t>& TDDCF;
+typedef const boost::tuple<real_t&, real_t&>& TDD;
+typedef const boost::tuple<int, string>& TIS;
+typedef const boost::tuple<int, int>& TII;
+typedef const boost::tuple<int, real_t>& TID;
+typedef const boost::tuple<int, set<int>&>& TISETI;
+typedef const boost::tuple<int&, bool, int>& TIBI;
+typedef const boost::tuple<real_t, Log<real_t>& >& TDL;
+typedef const boost::tuple<real_t&, Log<real_t>, Log<real_t> >& TDLL;
 typedef Log<real_t> prob_t;
 
 //global variables
@@ -334,18 +335,18 @@ indices(const R& r) {
   return span<typename boost::range_size<R>::type>(boost::size(r));
 }
 template <class R> static pair<
-  zip_iterator<tuple<
+  zip_iterator<boost::tuple<
                  counting_iterator<typename range_difference<R>::type>,
                  typename range_iterator<R>::type> >,
-  zip_iterator<tuple<
+  zip_iterator<boost::tuple<
                  counting_iterator<typename range_difference<R>::type>,
                  typename range_iterator<R>::type> > >
 enumerate(R& r) {
   return make_pair(
-      make_zip_iterator(make_tuple(
+      make_zip_iterator(boost::make_tuple(
           counting_iterator<typename range_difference<R>::type>(0),
           boost::begin(r))),
-      make_zip_iterator(make_tuple(
+      make_zip_iterator(boost::make_tuple(
           counting_iterator<typename range_difference<R>::type>(
               boost::size(r)),
           boost::end(r))));
@@ -408,7 +409,7 @@ pair<typename range_value<R>::type, typename range_value<R>::type>
 minmax(const R& r) {
   pair<
     typename range_const_iterator<R>::type,
-    typename range_const_iterator<R>::type> p = minmax_element(
+    typename range_const_iterator<R>::type> p = boost::minmax_element(
         boost::begin(r), boost::end(r));
   return make_pair(*p.first, *p.second);
 }
@@ -543,48 +544,48 @@ template <class R> static int arg_max(const R& r) {
 }
 template <class R1, class R2>
 static pair<
-  zip_iterator<tuple<
+  zip_iterator<boost::tuple<
                  typename range_iterator<R1>::type,
                  typename range_iterator<R2>::type> >,
-  zip_iterator<tuple<
+  zip_iterator<boost::tuple<
                  typename range_iterator<R1>::type,
                  typename range_iterator<R2>::type> > >
 zip(R1& r1, R2& r2) {
   size_t size = range_min_size(r1, r2);
   return make_pair(
-      make_zip_iterator(make_tuple(boost::begin(r1), boost::begin(r2))),
-      make_zip_iterator(make_tuple(
+      make_zip_iterator(boost::make_tuple(boost::begin(r1), boost::begin(r2))),
+      make_zip_iterator(boost::make_tuple(
           boost::end(r1) - (boost::size(r1) - size),
           boost::end(r2) - (boost::size(r2) - size))));
 }
 template <class R1, class R2, class R3>
 static pair<
-  zip_iterator<tuple<
+  zip_iterator<boost::tuple<
                  typename range_iterator<R1>::type,
                  typename range_iterator<R2>::type,
                  typename range_iterator<R3>::type> >,
-  zip_iterator<tuple<
+  zip_iterator<boost::tuple<
                  typename range_iterator<R1>::type,
                  typename range_iterator<R2>::type,
                  typename range_iterator<R3>::type> > >
 zip(R1& r1, R2& r2, R3& r3) {
   size_t size = range_min_size(r1, r2, r3);
   return make_pair(
-      make_zip_iterator(make_tuple(
+      make_zip_iterator(boost::make_tuple(
           boost::begin(r1), boost::begin(r2), boost::begin(r3))),
-      make_zip_iterator(make_tuple(
+      make_zip_iterator(boost::make_tuple(
           boost::end(r1) - (boost::size(r1) - size),
           boost::end(r2) - (boost::size(r2) - size),
           boost::end(r3) - (boost::size(r3) - size))));
 }
 template <class R1, class R2, class R3, class R4>
 static pair<
-  zip_iterator<tuple<
+  zip_iterator<boost::tuple<
                  typename range_iterator<R1>::type,
                  typename range_iterator<R2>::type,
                  typename range_iterator<R3>::type,
                  typename range_iterator<R4>::type> >,
-  zip_iterator<tuple<
+  zip_iterator<boost::tuple<
                  typename range_iterator<R1>::type,
                  typename range_iterator<R2>::type,
                  typename range_iterator<R3>::type,
@@ -592,10 +593,10 @@ static pair<
 zip(R1& r1, R2& r2, R3& r3, R4& r4) {
   size_t size = range_min_size(r1, r2, r3, r4);
   return make_pair(
-      make_zip_iterator(make_tuple(
+      make_zip_iterator(boost::make_tuple(
           boost::begin(r1), boost::begin(r2), boost::begin(r3),
           boost::begin(r4))),
-      make_zip_iterator(make_tuple(
+      make_zip_iterator(boost::make_tuple(
           boost::end(r1) - (boost::size(r1) - size),
           boost::end(r2) - (boost::size(r2) - size),
           boost::end(r3) - (boost::size(r3) - size),
@@ -603,13 +604,13 @@ zip(R1& r1, R2& r2, R3& r3, R4& r4) {
 }
 template <class R1, class R2, class R3, class R4, class R5>
 static pair<
-  zip_iterator<tuple<
+  zip_iterator<boost::tuple<
                  typename range_iterator<R1>::type,
                  typename range_iterator<R2>::type,
                  typename range_iterator<R3>::type,
                  typename range_iterator<R4>::type,
                  typename range_iterator<R5>::type> >,
-  zip_iterator<tuple<
+  zip_iterator<boost::tuple<
                  typename range_iterator<R1>::type,
                  typename range_iterator<R2>::type,
                  typename range_iterator<R3>::type,
@@ -618,10 +619,10 @@ static pair<
 zip(R1& r1, R2& r2, R3& r3, R4& r4, R5& r5) {
   size_t size = range_min_size(r1, r2, r3, r4, r5);
   return make_pair(
-      make_zip_iterator(make_tuple(
+      make_zip_iterator(boost::make_tuple(
           boost::begin(r1), boost::begin(r2), boost::begin(r3),
           boost::begin(r4), boost::begin(r5))),
-      make_zip_iterator(make_tuple(
+      make_zip_iterator(boost::make_tuple(
           boost::end(r1) - (boost::size(r1) - size),
           boost::end(r2) - (boost::size(r2) - size),
           boost::end(r3) - (boost::size(r3) - size),
@@ -801,29 +802,6 @@ template<class R1, class R2, class R3> static void range_divide(
 template<class R1, class R2> static void range_divide_equals(
     R1& a, const R2& b) {
   range_divide(a, a, b);
-}
-//TUPLE OPERATIONS
-template<class T1, class T2> static ostream& operator << (
-    ostream& out, const tuple<T1, T2>& t) {
-  out << t.get<0>() << " " << t.get<1>();
-  return out;
-}
-template<class T1, class T2, class T3> static ostream& operator << (
-    ostream& out, const tuple<T1, T2, T3>& t) {
-  out << t.get<0>() << " " << t.get<1>() << " " << t.get<2>();
-  return out;
-}
-template<class T1, class T2, class T3, class T4> static ostream& operator << (
-    ostream& out, const tuple<T1, T2, T3, T4>& t) {
-  out << t.get<0>() << " " << t.get<1>() << " " << t.get<2>() << " "
-      << t.get<3>();
-  return out;
-}
-template<class T1, class T2, class T3, class T4, class T5>
-static ostream& operator << (ostream& out, const tuple<T1, T2, T3, T4, T5>& t) {
-  out << t.get<0>() << " " << t.get<1>() << " " << t.get<2>() << " "
-      << t.get<3>() << " " << t.get<4>();
-  return out;
 }
 //PAIR OPERATIONS
 template<class T> static bool in_open_interval(pair<T,T> interval, T val) {

--- a/rnnlib4seshat/Helpers.hpp
+++ b/rnnlib4seshat/Helpers.hpp
@@ -388,10 +388,10 @@ static UnaryFunction for_each(R& r, UnaryFunction f) {
   return for_each(boost::begin(r), boost::end(r), f);
 }
 template <class R, class T> static bool in(const R& r, const T& t) {
-  return find(r, t) != boost::end(r);
+  return ::find(r, t) != boost::end(r);
 }
 template <class R, class T> static size_t index(const R& r, const T& t) {
-  return distance(boost::begin(r), find(r, t));
+  return distance(boost::begin(r), ::find(r, t));
 }
 template <class R> static void reverse(R& r) {
   reverse(boost::begin(r), boost::end(r));

--- a/rnnlib4seshat/WeightContainer.hpp
+++ b/rnnlib4seshat/WeightContainer.hpp
@@ -51,15 +51,15 @@ the following copyright and permission notice:
 
 using namespace std;
 
-typedef multimap<string, tuple<string, string, int, int> >::iterator WC_CONN_IT; 
-typedef pair<string, tuple<string, string, int, int> > WC_CONN_PAIR;
+typedef multimap<string, boost::tuple<string, string, int, int> >::iterator WC_CONN_IT; 
+typedef pair<string, boost::tuple<string, string, int, int> > WC_CONN_PAIR;
 
 struct WeightContainer: public DataExporter
 {
   //data
   Vector<real_t> weights;
   Vector<real_t> derivatives;
-  multimap<string, tuple<string, string, int, int> > connections;
+  multimap<string, boost::tuple<string, string, int, int> > connections;
 	
   //functions
   WeightContainer(DataExportHandler *deh):
@@ -68,7 +68,7 @@ struct WeightContainer: public DataExporter
   }
 
   void link_layers(const string& fromName, const string& toName, const string& connName = "", int paramBegin = 0, int paramEnd = 0) {
-    connections.insert(make_pair(toName, make_tuple(fromName, connName, paramBegin, paramEnd)));
+    connections.insert(make_pair(toName, boost::make_tuple(fromName, connName, paramBegin, paramEnd)));
   }
   
   pair<size_t, size_t> new_parameters(size_t numParams, const string& fromName, const string& toName, const string& connName) {


### PR DESCRIPTION
Disambiguate boost::tuple and std::tuple.

On 18.04 default libboost version is 1.65 and g++ is using c++11 and libxerces is 3.2.

This version of libxerces requires c++11 rendering the flag c++98 option useless (if you don't want to recompile).

In this patchset I just added references to force Helper.hpp to use the boost version of tuple (without them, it uses the new std::tuple or gets ambiguous calls).

I also added -fpermissive otherwise the build fails on perturb_weights function. 
 